### PR TITLE
Fixed splice_locked messgae to include splice_txid field and other interop fixes

### DIFF
--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -3306,7 +3306,7 @@ static void resume_splice_negotiation(struct peer *peer,
 	struct bitcoin_tx *bitcoin_tx;
 	u32 splice_funding_index;
 	const u8 *msg, *sigmsg;
-	u32 chan_output_index;
+	u32 new_output_index;
 	struct pubkey *their_pubkey;
 	struct bitcoin_tx *final_tx;
 	struct bitcoin_txid final_txid;
@@ -3337,8 +3337,8 @@ static void resume_splice_negotiation(struct peer *peer,
 					 &peer->channel->funding_pubkey[LOCAL],
 					 &peer->channel->funding_pubkey[REMOTE]);
 
-	find_channel_output(peer, current_psbt, &chan_output_index,
-			    &peer->channel->funding_pubkey[REMOTE]);
+	find_channel_output(peer, current_psbt, &new_output_index,
+			    &inflight->remote_funding);
 
 	splice_funding_index = find_channel_funding_input(current_psbt,
 							  &peer->channel->funding);
@@ -3622,7 +3622,7 @@ static void resume_splice_negotiation(struct peer *peer,
 
 		final_tx = bitcoin_tx_with_psbt(tmpctx, current_psbt);
 		msg = towire_channeld_splice_confirmed_signed(tmpctx, final_tx,
-							      chan_output_index);
+							      new_output_index);
 		wire_sync_write(MASTER_FD, take(msg));
 	}
 }

--- a/channeld/channeld.c
+++ b/channeld/channeld.c
@@ -3945,6 +3945,7 @@ static void splice_initiator(struct peer *peer, const u8 *inmsg)
 	ictx->shared_outpoint = tal(ictx, struct bitcoin_outpoint);
 	*ictx->shared_outpoint = peer->channel->funding;
 	ictx->funding_tx = prev_tx;
+	status_info("splice_initiator ictx->shared_outpoint = %s",(ictx->shared_outpoint?"defined":"null"));
 
 	peer->splicing->tx_add_input_count = 0;
 	peer->splicing->tx_add_output_count = 0;
@@ -3996,6 +3997,7 @@ static void splice_initiator_user_finalized(struct peer *peer)
 
 	ictx->shared_outpoint = tal(ictx, struct bitcoin_outpoint);
 	*ictx->shared_outpoint = peer->channel->funding;
+	status_info("splice_initiator_user_finalized: ictx->shared_outpoint = %s",(ictx->shared_outpoint?"defined":"null"));
 	ictx->funding_tx = prev_tx;
 
 	error = process_interactivetx_updates(tmpctx, ictx,
@@ -4143,6 +4145,10 @@ static void splice_initiator_user_update(struct peer *peer, const u8 *inmsg)
 	ictx->current_psbt = peer->splicing->current_psbt;
 	ictx->tx_add_input_count = peer->splicing->tx_add_input_count;
 	ictx->tx_add_output_count = peer->splicing->tx_add_output_count;
+
+	ictx->shared_outpoint = tal(ictx, struct bitcoin_outpoint);
+	*ictx->shared_outpoint = peer->channel->funding;
+	ictx->funding_tx = bitcoin_tx_from_txid(peer, peer->channel->funding.txid);
 
 	/* If there no are no changes, we consider the splice user finalized */
 	if (!interactivetx_has_changes(ictx, ictx->desired_psbt)) {

--- a/common/interactivetx.c
+++ b/common/interactivetx.c
@@ -227,12 +227,22 @@ static char *send_next(const tal_t *ctx,
 
 		/* If this the shared channel input, we send funding txid in
 		 * in tlvs and do not send prevtx */
+		status_info("ictx->shared_outpoint = %s",(ictx->shared_outpoint?"defined":"null"));
+		char txid_hex[65];
+		if (ictx->shared_outpoint && bitcoin_txid_to_hex(&(ictx->shared_outpoint->txid), txid_hex, sizeof(txid_hex))) {
+			status_info("ictx->shared_outpoint->txid=%s, ictx->shared_outpoint->n=%d", txid_hex, ictx->shared_outpoint->n);
+		}
+		if (bitcoin_txid_to_hex(&(point.txid), txid_hex, sizeof(txid_hex))) {
+			status_info("point.txid=%s, point.n=%d", txid_hex, point.n);
+		}
+		status_info("here2");
  		if (ictx->shared_outpoint
  			&& bitcoin_outpoint_eq(&point, ictx->shared_outpoint)) {
-			struct tlv_tx_add_input_tlvs *tlvs = tal(tmpctx, struct tlv_tx_add_input_tlvs);
+			struct tlv_tx_add_input_tlvs *tlvs = tlv_tx_add_input_tlvs_new(tmpctx);
 			tlvs->shared_input_txid = tal_dup(tlvs,
 							  struct bitcoin_txid,
 							  &point.txid);
+			status_info("Adding shared input %s", tal_hexstr(ctx, &serial_id, sizeof(serial_id)));
  			msg = towire_tx_add_input(NULL, cid, serial_id,
 						  NULL, in->input.index,
 						  in->input.sequence, tlvs);
@@ -240,6 +250,7 @@ static char *send_next(const tal_t *ctx,
 			msg = towire_tx_add_input(NULL, cid, serial_id,
 						  prevtx, in->input.index,
 						  in->input.sequence, NULL);
+			status_info("Adding splice input %s", tal_hexstr(ctx, &serial_id, sizeof(serial_id)));
 		}
 
 		tal_arr_remove(&set->added_ins, 0);

--- a/wire/peer_wire.csv
+++ b/wire/peer_wire.csv
@@ -223,6 +223,7 @@ msgdata,splice_ack,relative_satoshis,s64,
 msgdata,splice_ack,funding_pubkey,point,
 msgtype,splice_locked,77,
 msgdata,splice_locked,channel_id,channel_id,
+msgdata,splice_locked,splice_txid,sha256,
 msgtype,shutdown,38
 msgdata,shutdown,channel_id,channel_id,
 msgdata,shutdown,len,u16,


### PR DESCRIPTION
After Eclair successfully sends `splice_locked` I saw this message in the eclair log:

```log
2025-01-22 14:00:12,833 INFO  f.a.eclair.Diagnostics n:034f3bafd420714d9a2c0e6986a4109af5e934604f199eafef4076844c9faf0a4c c:daf879e0b02d7c4c23c15768a3c975d605165c08e38fefe1946daf0b92fb78b7 - OUT msg=SpliceLocked(daf879e0b02d7c4c23c15768a3c975d605165c08e38fefe1946daf0b92fb78b7,c8f7611495e85cab7cb244ffe87537ba1cf4104c527b9a0e08cb9dba45b4aa54,TlvStream(Set(),Set()))
2025-01-22 14:00:38,600 ERROR f.a.e.c.TransportHandler CON n:034f3bafd420714d9a2c0e6986a4109af5e934604f199eafef4076844c9faf0a4c - cannot deserialize 004ddaf879e0b02d7c4c23c15768a3c975d605165c08e38fefe1946daf0b92fb78b7: fundingTxHash: expected exactly 256 bits but got 0 bits
```
Apparently `splice_locked` in clightning is missing the `splice_txid` field as described in the [latest splice PR](https://github.com/lightning/bolts/blob/aece0d8f42310d7e7d128905cf18eb0414c02459/02-peer-protocol.md#the-splice_locked-message).

This PR includes the minimal changes I needed to continue my testing, but there are probably other things that should be done to check the `splice_txid` is correct, update tests, etc.